### PR TITLE
fix exceptions caused by names having \n in them.

### DIFF
--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -402,7 +402,7 @@ readFilesFromTTS = (self, files, onlyOpen = false) ->
   mode = atom.config.get('tabletopsimulator-lua.loadSave.communicationMode')
   createXML = atom.config.get('tabletopsimulator-lua.loadSave.createXML')
   for f, i in files
-    f.name = f.name.replace(/([":<>/\\|?*])/g, "")
+    f.name = f.name.replace(/([":<>/\\|?*\r\n])/g, "")
     basename = f.name + "." + f.guid + ".ttslua"
     # write ttslua script
     @file = new FileHandler(basename)


### PR DESCRIPTION
While you can't multi-line the name normally, a script however is able to force it,  and the end result is an exception and silent failure to retrieve scripts.