### PR TITLE
Added support for require()

### DIFF
--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -131,7 +131,6 @@ log_seperator = (tag) ->
 
 # #include system for inserting one file into another
 insertFileKeyword = '#include'
-insertFileSeperator = '|'
 insertLuaMarkerString = '(\\s*' + insertFileKeyword + '\\s+([^\\s].*))'
 insertLuaFileRegexp = RegExp('^' + insertLuaMarkerString)
 insertedLuaFileRegexp = RegExp('^----' + insertLuaMarkerString)
@@ -183,30 +182,6 @@ getRootPath = () ->
   if rootpath.match(/^~[\\/]/) # home dir selector ~
     rootpath = path.join(os.homedir(), rootpath[2..])
   return rootpath
-
-
-extractFileMap = (text, filepath) ->
-  lines = text.split(/\n/)
-  tree = {label: filepath, children: [], parent: null, startRow: 0, endRow: lines.length-1, depth: 0}
-  for line, row in lines
-    found = line.match(insertedLuaFileRegexp)
-    if found
-      if tree.parent
-        dir = path.dirname(tree.parent.label)
-      else # root node
-        dir = path.dirname(filepath)
-      label = completeFilepath(found[2], dir)
-      if tree.parent and tree.parent.label == label #closing include
-        tree.endRow = row
-        tree = tree.parent
-        if tree.parent == null
-          output.push(found[1])
-      else #opening include
-        tree.children.push({label: label, children: [], parent: tree, startRow: row + 1, endRow: null, depth: tree.depth + 1})
-        tree = tree.children[tree.children.length-1]
-        if not (label of appearsInFile)
-          appearsInFile[label] = {}
-        appearsInFile[label][filepath] = tree.depth
 
 
 isFromTTS = (fn) ->

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -591,7 +591,7 @@ module.exports = TabletopsimulatorLua =
         bundleSearchPath:
           title: 'Bundle file patterns'
           description: '''Bundle file patterns, semi-colon (;) separated. Patterns are relative to the #include base path and required file paths will be substituted for question mark (?) characters.'''
-          order: 5
+          order: 6
           type: 'string'
           default: defaultBundleSearchPath()
         delayLinter:

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1327,8 +1327,10 @@ module.exports = TabletopsimulatorLua =
     options = {
       expressionHandler: (module, expression) =>
         start = expression.loc.start
-        detail = "Non-literal require found in '" + module + "' at " + start.line + ":" + start.column
+        display_name = if module.name == bundleRootModule then filename else module.name
+        detail = "Non-literal require found in '" + display_name + "' at " + start.line + ":" + start.column
         atom.notifications.addWarning("Failed to create bundle: " + filename, {dismissable: true, detail: detail})
+        return null
       identifiers:
         require: bundleRequire
       isolate: true

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1285,7 +1285,7 @@ module.exports = TabletopsimulatorLua =
         catch error
           atom.notifications.addError(error.message, {dismissable: true, icon: 'type-file', detail: filepath})
       else
-        atom.notifications.addError("Could not catalog #include - file not found:", {icon: 'type-file', detail: filepath})
+        atom.notifications.addError("Could not catalog <Include /> - file not found:", {icon: 'type-file', detail: filepath})
       if filetext
         if filepath of alreadyInserted
           atom.notifications.addError("Cyclical " + atom.config.get('tabletopsimulator-lua.loadSave.includeKeyword') + " detected.", {dismissable: true, icon: 'type-file', detail: filepath})

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
-    "luabundle": "^1.1.0",
+    "luabundle": "^1.2.1",
     "luaparse": "^0.2.0",
     "mkdirp": "~0.5.1",
     "q": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
     }
   },
   "dependencies": {
-    "mkdirp": "~0.3.5",
-    "space-pen": "^5.1.1",
     "atom-space-pen-views": "^2.0.0",
+    "luabundle": "^1.1.0",
     "luaparse": "^0.2.0",
-    "q": "^1.5.1"
+    "mkdirp": "~0.5.1",
+    "q": "^1.5.1",
+    "space-pen": "^5.1.1"
   }
 }


### PR DESCRIPTION
Adds seamless support for standard Lua modules with `require(filename)` syntax.

`require()` statements are resolved when Atom saves and pushes to TTS. When this happens a bundle is generated with marker comments, much like `#include`. Unbundling occurs when we pull files from TTS, again, similar to how `#include` works.

Two new configuration options have been added to the Atom extension:

* "require() other files" toggle (default enabled, but can be disabled like `#include`)
* "Bundle file patterns", which is how Lua resolves require file paths (https://www.lua.org/pil/8.1.html). Sensible default chosen.

Files are resolved relative to the existing `includeOtherFilesPath` option, and text has been updated to reflect this.
