### PR TITLE
Added support for require(): Take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
-    "luabundle": "^1.2.1",
-    "moonsharp-luaparse": "^0.2.1",
+    "luabundle": "^1.4.0",
     "mkdirp": "~0.5.1",
+    "moonsharp-luaparse": "^0.2.3",
     "q": "^1.5.1",
     "space-pen": "^5.1.1"
   }


### PR DESCRIPTION
- No more injecting comments through-out the generated Lua bundles.
- No regex magic necessary to unbundle, this behavior is delegated to luabundle; which properly parses the Lua in order to unbundle.
- Error source mapping now works correctly for bundles.
- You may now put `#include` and `require()` in the one TTS script.
  However, files that are bundled as a result of a `require()` must be standard MoonSharp Lua (they cannot use `#include`) i.e. you may `#include` a file with a `require()`, but not vice versa.