### PR TITLE
Better require() error handling and fixed support of != syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
-    "luabundle": "^1.4.0",
+    "luabundle": "^1.5.0",
     "mkdirp": "~0.5.1",
-    "moonsharp-luaparse": "^0.2.3",
+    "moonsharp-luaparse": "^0.2.4",
     "q": "^1.5.1",
     "space-pen": "^5.1.1"
   }


### PR DESCRIPTION
Updated `moonsharp-luaparse`, which now supports additional MoonSharp specific syntax:

- `!=` as an alternative to `~=`
- Comma separated index list i.e. `some_userdata[1, 2, 3]`

The latter of which is a MoonSharp extension that [only works for `userdata`](www.moonsharp.org/additions.html#language-differences) so is only useful if at some point Berserk want to take advantage of the syntax.

Additionally, `luabundle` has been updated and now includes custom errors (rather than just textual errors). Thus if something goes wrong during bundling/unbundling we can tell which module had the problem and the underlying cause. As a result, we now have special case handling for Lua syntax errors that are encountered during bundling. In which case we bring up a notification explaining that there's a syntax error and have a "Jump to Error" button e.g.

![Screen Shot 2020-02-20 at 4 55 57 am](https://user-images.githubusercontent.com/482276/74860841-6fddd000-539d-11ea-85b1-7942337e9afe.png)
