### PR TITLE
Fixed typo in spawnObject({...})

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -4853,7 +4853,7 @@ module.exports =
               'position          = ${2:-- Vector [x=0, y=3, z=0]},\n\t' +
               'rotation          = ${3:-- Vector [x=0, y=0, z=0]},\n\t' +
               'scale             = ${4:-- Vector [x=1, y=1, z=1]},\n\t' +
-              'callback_fucntion = ${5:-- function},\n\t' +
+              'callback_function = ${5:-- function},\n\t' +
               'sound             = ${6:-- bool},\n\t' +
               'params            = ${7:-- Table},\n\t' +
               'snap_to_grid      = ${8:-- bool},\n' +


### PR DESCRIPTION
I also saw that the `params` in spawnObject is not in the documentation, but I'm not sure if it's old or new, so I left it. If it's dead code then I'll gladly edit this to remove it as well.