### PR TITLE
updating the file path to reflect windows Save location

### DIFF
--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -173,7 +173,9 @@ includeShouldBeEnclosed = (filepath) ->
   return filepath.startsWith('<') and filepath.endsWith('>')
 
 defaultIncludeOtherFilesPath = () ->
-  return path.join('~', 'Documents', 'My Games', 'Tabletop Simulator')
+  switch os.platform()
+    when 'win32' then path.join('~', 'Documents', 'My Games', 'Tabletop Simulator')
+    else path.join('~', 'Documents', 'Tabletop Simulator')
 
 getRootPath = () ->
   rootpath = atom.config.get('tabletopsimulator-lua.loadSave.includeOtherFilesPath') || defaultIncludeOtherFilesPath()

--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -173,7 +173,7 @@ includeShouldBeEnclosed = (filepath) ->
   return filepath.startsWith('<') and filepath.endsWith('>')
 
 defaultIncludeOtherFilesPath = () ->
-  return path.join('~', 'Documents', 'Tabletop Simulator')
+  return path.join('~', 'Documents', 'My Games', 'Tabletop Simulator')
 
 getRootPath = () ->
   rootpath = atom.config.get('tabletopsimulator-lua.loadSave.includeOtherFilesPath') || defaultIncludeOtherFilesPath()


### PR DESCRIPTION
The user configuration for Tabletop Simulator on windows is by default found in  '~/'Documents/My Games/Tabletop Simulator'
I have changed the defaultIncludeOtherFilesPath to reflect this.
This may be platform dependent in which case I recommend a switch statement