### PR TITLE
Fix Save & Play

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -1,5 +1,6 @@
 /// <reference path="../typings/hover.d.ts" />
 var child_process = require('child_process');
+var remote = require('electron').remote;
 var Q = require('q');
 function provider(p) {
     function okInfo(text) {
@@ -10,11 +11,15 @@ function provider(p) {
         return { valid: false, info: text.join('\n') };
     }
     function errInfo(text) {
-        atom.confirm({
+        remote.dialog.showMessageBox(remote.getCurrentWindow(), {
+            type: 'info',
+            normalizeAccessKeys: true,
             message: "Hover Info Error" + text,
             detailedMessage: text,
-            buttons: {
-                Close: function () { window.alert('ok'); }
+            buttons: ['Close']
+        }).then(function(event) {
+            if (event.response === 0) {
+                window.alert('ok')
             }
         });
         return { valid: false, info: text };


### PR DESCRIPTION
Closes #126

Save & Play still fails from time-to-time on TTS end (not accepting connections), however, this at least gets us back to functional on our end.

Looks like the underlying cause is [this breaking change](https://github.com/electron/electron/pull/17298) in Electron, and Atom hasn't updated its `atom.confirm` implementation (https://github.com/atom/atom/blame/1d9a4cafcf6cc288d675512db8fd984e13aab869/src/application-delegate.js#L231-L235).

I'll submit a PR to Atom itself shortly.