### PR TITLE
Applied fix discussed in discord for XML.

### DIFF
--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -1344,10 +1344,12 @@ module.exports = TabletopsimulatorLua =
                 if ui != ''
                   count += 1
 
-          if atom.config.get('tabletopsimulator-lua.loadSave.includeOtherFiles')
-            for @luaObject in @luaObjects.scriptStates
-              if @luaObject.guid of uis
+          for @luaObject in @luaObjects.scriptStates
+            if @luaObject.guid of uis
+              if atom.config.get('tabletopsimulator-lua.loadSave.includeOtherFiles')
                 @luaObject.ui = @insertXmlFiles(uis[@luaObject.guid])
+              else
+                @luaObject.ui = uis[@luaObject.guid]
 
           #destroyTTSEditors()
           #deleteCachedFiles()


### PR DESCRIPTION
Applied the fix discussed with onelivesleft in Discord to fix XML being sent even when tabletopsimulator-lua.loadSave.includeOtherFiles is false.

All code changed was written by @onelivesleft. No code changed was written by me. All I did was put it in the right location.

Don't know if this is 100% correct. Just wanted to bring this back into attention.