### PR TITLE
Fixed handling of luabundled mods with a non-default root module name

### DIFF
--- a/lib/tabletopsimulator-lua.coffee
+++ b/lib/tabletopsimulator-lua.coffee
@@ -380,11 +380,12 @@ unbundle = (filepath, text) ->
   try
     data = luabundle.unbundleString(text)
     searchPaths = getBundleSearchPaths()
+    rootModuleName = data.metadata.rootModuleName
     rootModuleSourceMap = sourceMap
 
     for _, module of data.modules
-      if module.name == bundleRootModule
-        rootModuleSourceMap =  {path: null, children: [], startRow: module.start.line - 1, endRow: module.end.line - 1}
+      if module.name == rootModuleName
+        rootModuleSourceMap = {path: null, children: [], startRow: module.start.line - 1, endRow: module.end.line - 1}
         sourceMap.children.push(rootModuleSourceMap)
       else
         modulePath = resolveBundleModule(module.name, searchPaths)
@@ -394,7 +395,7 @@ unbundle = (filepath, text) ->
               appearsInFile[modulePath] = {}
             appearsInFile[modulePath][filepath] = true
 
-    return [data.modules[bundleRootModule].content, rootModuleSourceMap]
+    return [data.modules[rootModuleName].content, rootModuleSourceMap]
   catch error
     if error not instanceof NoBundleMetadataError # If there's no metadata, then it's not a bundle.
       atom.notifications.addError("Failed to unbundle: " + filepath, {dismissable: true, detail: error.message})


### PR DESCRIPTION
The root module (entry point) in a luabundled script doesn't have an explicit filename, as it's not ever itself `require`'d. By default luabundle gives the root module the placeholder name `__root`, and that's the name this Atom plugin sticks with. 

When unbundling (fetching lua scripts) we do need to grab the root module and write it to a temporary file. Prior to this PR, we assumed Atom created the TTS mod, and thus we expect to find a module named `__root`.

However, [VSCode](https://github.com/rolandostar/tabletopsimulator-lua-vscode) does _not_ use the default module name `__root`, so our assumption that one exists leads to the following error when opening a mod created with the aforementioned VSCode plugin:

![unknown](https://user-images.githubusercontent.com/482276/136315916-46c7857a-be37-4fb4-8449-4d54f9f8743f.png)

luabundle has built-in support retrieving the utilised root module name when unbundling, so this PR takes advantage of this functionality rather than using the hard-coded module name `__root`.